### PR TITLE
FI-4182: Update gemspec: remove email and set authors to Inferno Team

### DIFF
--- a/cancer_pathology_data_sharing_test_kit.gemspec
+++ b/cancer_pathology_data_sharing_test_kit.gemspec
@@ -3,8 +3,7 @@ require_relative 'lib/cancer_pathology_data_sharing_test_kit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'cancer_pathology_data_sharing_test_kit'
   spec.version       = CancerPathologyDataSharingTestKit::VERSION
-  spec.authors       = ['Robert Passas', 'Diego Griese', 'Christine Duong', 'Karl Naden']
-  spec.email         = ['inferno@groups.mitre.org']
+  spec.authors       = ['Inferno Team']
   spec.summary       = 'Cancer Pathology Data Sharing IG Test Kit'
   spec.description   = 'Inferno test kit for testing systems per the Cancer Pathology Data Sharing IG'
   spec.homepage      = 'https://github.com/inferno-framework/cancer-pathology-data-sharing-test-kit/'


### PR DESCRIPTION
Email isn't required for gemspec, according to the spec: https://guides.rubygems.org/specification-reference/

Also updated the authors to be more generic.